### PR TITLE
De runargs para secrets no devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,16 +18,16 @@
 	},
 	"secrets": {
 		"AWS_ACCESS_KEY_ID": {
-			"description": "AWS Access Key ID",
+			"description": "AWS Access Key ID"
 		},
 		"AWS_SECRET_ACCESS_KEY": {
-			"description": "AWS Secret Access",
+			"description": "AWS Secret Access"
 		},
 		"AWS_DEFAULT_REGION": {
-			"description": "AWS Default Region",
+			"description": "AWS Default Region"
 		},
 		"AWS_SESSION_TOKEN": {
-			"description": "AWS Session Token (optional)",
+			"description": "AWS Session Token (optional)"
 		}
 	}	
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,11 +16,18 @@
 		]
 	  }
 	},
-	"runArgs": [
-	  "--env", "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}",
-	  "--env", "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}",
-	  "--env", "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}",
-	  "--env", "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}",
-	  "--env", "AWS_CLI_AUTO_PROMPT=on-partial"
-	]
+	"secrets": {
+		"AWS_ACCESS_KEY_ID": {
+			"description": "AWS Access Key ID",
+		},
+		"AWS_SECRET_ACCESS_KEY": {
+			"description": "AWS Secret Access",
+		},
+		"AWS_DEFAULT_REGION": {
+			"description": "AWS Default Region",
+		},
+		"AWS_SESSION_TOKEN": {
+			"description": "AWS Session Token (optional)",
+		}
+	}	
   }


### PR DESCRIPTION
De runargs para secrets no devcontainer. Dar merge para histórico. Posteriormente usar via script em vez do repo secret.